### PR TITLE
POR-9025-Update-gRPC-SDK-platform-libraries

### DIFF
--- a/Casks/grpc-java.rb
+++ b/Casks/grpc-java.rb
@@ -1,6 +1,6 @@
 cask 'grpc-java' do
-  version '1.56.1'
-  sha256 '1875e3035f03bd3dd457c24ed8aa9d132ef1a3d06432606fbe1fdb7589a3014f'
+  version '1.61.0'
+  sha256 'd865fdcadf5d1dbda42e0c97ad4207e30da4c1e01bf7c02ae014521de2f5ae6d'
 
   url "https://search.maven.org/remotecontent?filepath=io/grpc/protoc-gen-grpc-java/#{version}/protoc-gen-grpc-java-#{version}-osx-x86_64.exe"
   name 'grpc-java'

--- a/grpc-swift.rb
+++ b/grpc-swift.rb
@@ -2,7 +2,7 @@ class GrpcSwift < Formula
   desc "The Swift language implementation of gRPC"
   homepage "https://github.com/grpc/grpc-swift"
   url "https://github.com/grpc/grpc-swift.git",
-      :tag      => "1.18.0"
+      :tag      => "1.21.0"
   head "https://github.com/grpc/grpc-swift.git"
 
   depends_on :xcode => ["10.0", :build]


### PR DESCRIPTION
Updated:

* grpc-java from 1.56.1 to 1.61.0
* grpc-swift from 1.18.0 to 1.21.0

Note, we are using grpc-web without a custom formula so it's always up to date
And the grpc-php project is archived so it will never be updated anymore